### PR TITLE
README: fix "More Resources" subheading

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you have a [support plan](https://aws.amazon.com/premiumsupport/) with AWS Su
 
 You can also [open an issue](https://github.com/aws/res/issues/new/choose) and choose from one of our templates for guidance, bug reports, or feature requests. Please check for open [similar issues](https://github.com/aws/res/issues) before opening another one.
   		  
-##More Resources
+## More Resources
   		   		  
 * [Changelog](https://github.com/aws/res/blob/mainline/CHANGELOG.md)
 * [Amazon Web Services Discussion Forums](https://repost.aws/) 


### PR DESCRIPTION
## What does this PR do?

The `More Resources` heading in the README is missing a space after the `##`. This fixes it.

## How was this PR tested?

View the rendered README markdown.

### Checklist

- Make sure you are pointing to the right branch.
- If you're creating a patch for a branch other than develop add the branch name as prefix in the PR title.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure to have added unit tests or integration tests to cover the new/modified code.
- Check if documentation is impacted by this change.
- Link to impacted open issues.
- Link to related PRs in other packages (i.e. cookbook, node).
- Link to documentation useful to understand the changes.

## License

Please review the guidelines for contributing and Pull Request Instructions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.te this contribution, under the terms of your choice.