### PR TITLE
Windows VM domain join process uses the DC where the Computer Account was Created

### DIFF
--- a/source/idea/idea-bootstrap/_templates/windows/join_activedirectory.jinja2
+++ b/source/idea/idea-bootstrap/_templates/windows/join_activedirectory.jinja2
@@ -121,13 +121,14 @@ function Start-ADAutomationWaitForAuthorizationAndJoin
 
   if ($authorizationEntry.status -eq "success")
   {
-    Write-Host "[Join AD] authorization successful. joining AD, Domain: $AD_DOMAIN_NAME, OTP: $($authorizationEntry.otp) ..."
+    Write-Host "[Join AD] authorization successful. joining AD, Domain: $AD_DOMAIN_NAME, DC: $authorizationEntry.domain_controller, OTP: $($authorizationEntry.otp) ..."
     $joinCred = New-Object pscredential -ArgumentList ([pscustomobject]@{
       UserName = $null
       Password = (ConvertTo-SecureString -String $($authorizationEntry.otp) -AsPlainText -Force)[0]
     })
     Add-Computer -Domain $AD_DOMAIN_NAME `
                  -Options UnsecuredJoin, PasswordPass `
+                 -Server $authorizationEntry.domain_controller `
                  -Credential $joinCred
   }
   else


### PR DESCRIPTION
## What does this PR do?

When you have multiple domain controllers in an AD domain, potentially objects can take a while to synchronize. In the case of RES, when the creation of a Windows Virtual machine is created, a computer account is created on the domain (and the DC is recorded in DynamoDB), but when the VM is domain joined, it is not guaranteed to join using the same domain controller. This can cause delays while waiting for the computer account to become available on the domain controller.

In the PowerShell cmdlet that is used to join the domain on the Windows VM, "Add-Computer", this specifies the "-Server" switch, and supplies the original domain controller as the argument.

_Please add links to any issues, RFCs or other items that are relevant to this PR._
[Domain Join Windows VMs to the same domain controller where the computer account was created](https://github.com/aws/res/issues/55)

## How was this PR tested?

_Please describe any testing performed._ 
- The  file that was modified in this is "source/idea/idea-bootstrap/_templates/windows/join_activedirectory.jinja2". This change was tested in a base RES environment deployed using the [demo stack](https://docs.aws.amazon.com/res/latest/ug/create-demo-env.html)

### Checklist

- Make sure you are pointing to the right branch.
- If you're creating a patch for a branch other than develop add the branch name as prefix in the PR title.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure to have added unit tests or integration tests to cover the new/modified code.
- Check if documentation is impacted by this change.
- Link to impacted open issues.
- Link to related PRs in other packages (i.e. cookbook, node).
- Link to documentation useful to understand the changes.

## License

Please review the guidelines for contributing and Pull Request Instructions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.te this contribution, under the terms of your choice.