### PR TITLE
fix: dead loop inside SocaCliContext.aws() in case of SSO credentials

### DIFF
--- a/source/idea/idea-sdk/src/ideasdk/aws/aws_client_provider.py
+++ b/source/idea/idea-sdk/src/ideasdk/aws/aws_client_provider.py
@@ -19,6 +19,7 @@ from threading import RLock
 from typing import List, Dict, Any, Optional, Set
 import botocore.exceptions
 from botocore.client import Config
+from botocore.credentials import DeferredRefreshableCredentials
 
 AWS_CLIENT_S3 = 's3'
 AWS_CLIENT_EC2 = 'ec2'
@@ -245,6 +246,9 @@ class AwsClientProvider(AwsClientProviderProtocol):
                 else:
                     raise e
         else:
+            # To prevent a dead loop for SSO credentials
+            if isinstance(credentials, DeferredRefreshableCredentials):
+                credentials.get_frozen_credentials()
             return credentials.refresh_needed(refresh_in=30)
 
     def supported_clients(self) -> Set[str]:


### PR DESCRIPTION
## What does this PR do?

Fix dead loop inside SocaCliContext.aws()

When AWS credentials are received via SSO, the original code is entering an endless loop, resulting in a RecursionError exception. 
To replicate error:
```
aws sso login
invoke admin.test-iam-policies --cluster-name res-demo --aws-region eu-west-1 
```

## How was this PR tested?

_Please describe any testing performed._ 
- Describe the automated and/or manual tests executed to validate the patch.
- Describe the added/modified tests.

Manual test:
```
aws sso login
invoke admin.test-iam-policies --cluster-name res-demo --aws-region eu-west-1 
```

### Checklist

- Make sure you are pointing to the right branch.
- If you're creating a patch for a branch other than develop add the branch name as prefix in the PR title.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure to have added unit tests or integration tests to cover the new/modified code.
- Check if documentation is impacted by this change.
- Link to impacted open issues.
- Link to related PRs in other packages (i.e. cookbook, node).
- Link to documentation useful to understand the changes.

## License

Please review the guidelines for contributing and Pull Request Instructions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.te this contribution, under the terms of your choice.