### PR TITLE
Fix: "My Virtual Desktop" view shows other users' desktops

### DIFF
--- a/source/idea/idea-cluster-manager/webapp/src/pages/virtual-desktops/my-virtual-desktop-sessions.tsx
+++ b/source/idea/idea-cluster-manager/webapp/src/pages/virtual-desktops/my-virtual-desktop-sessions.tsx
@@ -260,7 +260,7 @@ class MyVirtualDesktopSessions extends Component<MyVirtualDesktopSessionsProps, 
                     },
                     {
                         key: "owner",
-                        value: AppContext.get().auth().getUsername(),
+                        eq: AppContext.get().auth().getUsername(),
                     }
                 ],
                 paginator: {
@@ -272,7 +272,18 @@ class MyVirtualDesktopSessions extends Component<MyVirtualDesktopSessionsProps, 
             cursor = result.paginator?.cursor;
         } while (cursor);
 
-        return response;
+        const filteredResponse: ListSessionsResponse = {
+            paginator: { page_size: 100 },
+            listing: [],
+        }
+
+        response.listing?.forEach(function(element) {
+            if(element.owner === AppContext.get().auth().getUsername()) {
+                filteredResponse.listing?.push(element);
+            }
+        });
+
+        return filteredResponse;
     }
 
     setFlashMessage = (content: React.ReactNode, type: "success" | "info" | "error") => {

--- a/source/idea/idea-virtual-desktop-controller/src/ideavirtualdesktopcontroller/app/sessions/virtual_desktop_session_db.py
+++ b/source/idea/idea-virtual-desktop-controller/src/ideavirtualdesktopcontroller/app/sessions/virtual_desktop_session_db.py
@@ -302,7 +302,7 @@ class VirtualDesktopSessionDB(VirtualDesktopNotifiableDB):
             
         request.filters.append(SocaFilter(
             key=sessions_constants.USER_SESSION_DB_FILTER_OWNER_KEY,
-            value=username
+            eq=username
         ))
         return self.list_all_from_db(request)
 


### PR DESCRIPTION
# What does this PR do?

Fixes an issue where "My Virtual Desktop" view incorrectly showing  all Virtual Desktops whose "owner" field contained the user's username. For example, user `min` can view all of user `Clusteradmin`'s Virtual Desktops, regardless of permissions.

## Issue:

`Clusteradmin` user's "My Virtual Desktop" view correctly shows the Virtual Desktop launched by the `Clusteradmin` user:
 
<img width="1717" height="817" alt="Screenshot_2025-07-25_at_10 41 04_AM" src="https://github.com/user-attachments/assets/345b123e-a487-47c3-b934-c070b59bd215" />

`min` user's "My Virtual Desktop" view incorrectly shows the Virtual Desktop deployed by the `Clusteradmin` user

<img width="1724" height="804" alt="Screenshot_2025-07-25_at_10 41 40_AM" src="https://github.com/user-attachments/assets/369d97ea-ecdd-432c-9240-e0e56bc0e176" />

## Change log:

- Replaced `value` filter for the `owner` field with `eq` filter in the `list_all_for_user` function. 
- Added additional `owner` filtering in the `fetchUserSessions` function.

# How was this PR tested?

Manual test:
- Deploy a new AWS RES instance using this branch.
- Created a new project and added a software stack using the AWS RES UI
- Launched a new virtual desktop using the `Clusteradmin` account
- Created an additional Cognito user named `min` and synced the changes in the Cognito Database with AWS RES using the `cognito-sync-lambda`
- Logged in using the `min` username and password
- Verified that the `min` user's "My Virtual Desktop" view did not show the `Clusteradmin` user's Virtual Desktop

`Clusteradmin` "My Virtual Desktop" view:

<img width="1717" height="817" alt="Screenshot_2025-07-25_at_10 41 04_AM (1)" src="https://github.com/user-attachments/assets/5fc30354-9501-443f-9a0b-e7d16d0dd18c" />

`min` "My Virtual Desktop" view:

<img width="1725" height="775" alt="Screenshot_2025-07-25_at_10 43 23_AM" src="https://github.com/user-attachments/assets/7f8c8a39-b0d2-4540-89c7-26659be26eb6" />

# License
 
Please review the guidelines for contributing and Pull Request Instructions.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.te this contribution, under the terms of your choice.